### PR TITLE
Make return type more specific

### DIFF
--- a/Classes/UITableView+FDTemplateLayoutCell.m
+++ b/Classes/UITableView+FDTemplateLayoutCell.m
@@ -25,7 +25,7 @@
 
 @implementation UITableView (FDTemplateLayoutCell)
 
-- (id)fd_templateCellForReuseIdentifier:(NSString *)identifier;
+- (UITableViewCell *)fd_templateCellForReuseIdentifier:(NSString *)identifier;
 {
     NSAssert(identifier.length > 0, @"Expects a valid identifier - %@", identifier);
     


### PR DESCRIPTION
Since return type is always ```UITableViewCell``` it's ok to have more specific return type.