### PR TITLE
支持reloadData时不删除原来的高度缓存

### DIFF
--- a/Classes/UITableView+FDTemplateLayoutCell.h
+++ b/Classes/UITableView+FDTemplateLayoutCell.h
@@ -59,6 +59,11 @@
 ///
 @property (nonatomic, assign) BOOL fd_debugLogEnabled;
 
+/**
+ *  Use this if you don't want to remove cache when reload tableView
+ */
+- (void)fd_reloadData:(BOOL)shouldRemoveCache;
+
 @end
 
 @interface UITableViewCell (FDTemplateLayoutCell)

--- a/Classes/UITableView+FDTemplateLayoutCell.m
+++ b/Classes/UITableView+FDTemplateLayoutCell.m
@@ -277,6 +277,15 @@ static CGFloat const _FDTemplateLayoutCellHeightCacheAbsentValue = -1;
 
 @implementation UITableView (FDTemplateLayoutCellAutomaticallyCacheInvalidation)
 
+- (void)fd_reloadData:(BOOL)shouldRemoveCache
+{
+    if (self.fd_autoCacheInvalidationEnabled && shouldRemoveCache) {
+        [self.fd_cellHeightCache.sections removeAllObjects];
+    }
+    [self fd_reloadData]; // Primary call
+    [self fd_precacheIfNeeded];
+}
+
 + (void)load
 {
     // All methods that trigger height cache's invalidation
@@ -305,11 +314,7 @@ static CGFloat const _FDTemplateLayoutCellHeightCacheAbsentValue = -1;
 
 - (void)fd_reloadData
 {
-    if (self.fd_autoCacheInvalidationEnabled) {
-        [self.fd_cellHeightCache.sections removeAllObjects];
-    }
-    [self fd_reloadData]; // Primary call
-    [self fd_precacheIfNeeded];
+    [self fd_reloadData:YES];
 }
 
 - (void)fd_insertSections:(NSIndexSet *)sections withRowAnimation:(UITableViewRowAnimation)animation

--- a/Classes/UITableView+FDTemplateLayoutCell.m
+++ b/Classes/UITableView+FDTemplateLayoutCell.m
@@ -488,10 +488,12 @@ static CGFloat const _FDTemplateLayoutCellHeightCacheAbsentValue = -1;
                                      attribute:NSLayoutAttributeNotAnAttribute
                                     multiplier:1.0
                                       constant:contentViewWidth];
-        [cell.contentView addConstraint:tempWidthConstraint];
-        // Auto layout engine does its math
-        fittingSize = [cell.contentView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
-        [cell.contentView removeConstraint:tempWidthConstraint];
+        @synchronized(cell.contentView) {
+            [cell.contentView addConstraint:tempWidthConstraint];
+            // Auto layout engine does its math
+            fittingSize = [cell.contentView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
+            [cell.contentView removeConstraint:tempWidthConstraint];
+        }
         
     } else {
         


### PR DESCRIPTION
应该有很多人在添加新数据，又不需要动画的时候会调用 reloadData。
这时候清除缓存很不划算
