### PR TITLE
fix condition bug about debugging log.

### DIFF
--- a/Classes/UITableView+FDTemplateLayoutCell.m
+++ b/Classes/UITableView+FDTemplateLayoutCell.m
@@ -60,18 +60,19 @@
     
     CGFloat fittingHeight = 0;
     
+    static BOOL isSystemVersionEqualOrGreaterThan10_2 = NO;
+
     if (!cell.fd_enforceFrameLayout && contentViewWidth > 0) {
         // Add a hard width constraint to make dynamic content views (like labels) expand vertically instead
         // of growing horizontally, in a flow-layout manner.
         NSLayoutConstraint *widthFenceConstraint = [NSLayoutConstraint constraintWithItem:cell.contentView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:contentViewWidth];
 
         // [bug fix] after iOS 10.3, Auto Layout engine will add an additional 0 width constraint onto cell's content view, to avoid that, we add constraints to content view's left, right, top and bottom.
-        static BOOL isSystemVersionEqualOrGreaterThan10_2 = NO;
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
             isSystemVersionEqualOrGreaterThan10_2 = [UIDevice.currentDevice.systemVersion compare:@"10.2" options:NSNumericSearch] != NSOrderedAscending;
         });
-        
+
         NSArray<NSLayoutConstraint *> *edgeConstraints;
         if (isSystemVersionEqualOrGreaterThan10_2) {
             // To avoid confilicts, make width constraint softer than required (1000)
@@ -103,7 +104,9 @@
     if (fittingHeight == 0) {
 #if DEBUG
         // Warn if using AutoLayout but get zero height.
-        if (cell.contentView.constraints.count > 0) {
+        // The contentView always gets 4 initial constraints in iOS 10.3.
+        NSUInteger initialConstraintCount = isSystemVersionEqualOrGreaterThan10_2 ? 4 : 0;
+        if (!cell.fd_enforceFrameLayout && cell.contentView.constraints.count > initialConstraintCount) {
             if (!objc_getAssociatedObject(self, _cmd)) {
                 NSLog(@"[FDTemplateLayoutCell] Warning once only: Cannot get a proper cell height (now 0) from '- systemFittingSize:'(AutoLayout). You should check how constraints are built in cell, making it into 'self-sizing' cell.");
                 objc_setAssociatedObject(self, _cmd, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/Classes/UITableView+FDTemplateLayoutCell.m
+++ b/Classes/UITableView+FDTemplateLayoutCell.m
@@ -66,14 +66,14 @@
         NSLayoutConstraint *widthFenceConstraint = [NSLayoutConstraint constraintWithItem:cell.contentView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:contentViewWidth];
 
         // [bug fix] after iOS 10.3, Auto Layout engine will add an additional 0 width constraint onto cell's content view, to avoid that, we add constraints to content view's left, right, top and bottom.
-        static BOOL isSystemVersionEqualOrGreaterThen10_2 = NO;
+        static BOOL isSystemVersionEqualOrGreaterThan10_2 = NO;
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
-            isSystemVersionEqualOrGreaterThen10_2 = [UIDevice.currentDevice.systemVersion compare:@"10.2" options:NSNumericSearch] != NSOrderedAscending;
+            isSystemVersionEqualOrGreaterThan10_2 = [UIDevice.currentDevice.systemVersion compare:@"10.2" options:NSNumericSearch] != NSOrderedAscending;
         });
         
         NSArray<NSLayoutConstraint *> *edgeConstraints;
-        if (isSystemVersionEqualOrGreaterThen10_2) {
+        if (isSystemVersionEqualOrGreaterThan10_2) {
             // To avoid confilicts, make width constraint softer than required (1000)
             widthFenceConstraint.priority = UILayoutPriorityRequired - 1;
             
@@ -93,7 +93,7 @@
         
         // Clean-ups
         [cell.contentView removeConstraint:widthFenceConstraint];
-        if (isSystemVersionEqualOrGreaterThen10_2) {
+        if (isSystemVersionEqualOrGreaterThan10_2) {
             [cell removeConstraints:edgeConstraints];
         }
         


### PR DESCRIPTION
This PR contains two commits.One for the typo issue,and another for the log issue.
Here's something about the debugging log issue.The `contentView` is added into a cell using auto-layout instead of frame in iOS 10.3.According to the log of a cell created with `frame`,we can see these constraints below:
```shell
(lldb) po cell.contentView.constraints
<__NSArrayI 0x174050e60>(
<NSLayoutConstraint:0x17409f4a0 'UIView-Encapsulated-Layout-Height' UITableViewCellContentView:0x10041a110.height == 44   (active)>,
<NSAutoresizingMaskLayoutConstraint:0x17409f4f0 h=--- v=--- 'UIView-Encapsulated-Layout-Left' UITableViewCellContentView:0x10041a110.minX == 0   (active, names: '|':TableViewCell:0x10085de00'TableViewCell' )>,
<NSAutoresizingMaskLayoutConstraint:0x17409f540 h=--- v=--- 'UIView-Encapsulated-Layout-Top' UITableViewCellContentView:0x10041a110.minY == 0   (active, names: '|':TableViewCell:0x10085de00'TableViewCell' )>,
<NSLayoutConstraint:0x17409f450 'UIView-Encapsulated-Layout-Width' UITableViewCellContentView:0x10041a110.width == 320   (active)>
)
```
Right.It always gets 4 initial constraints.
Hope this helps although it's just a debugging log issue.